### PR TITLE
Update junixsocket to v2.2.0 to support ARM, Win10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<slf4j-api.version>1.7.25</slf4j-api.version>
 
 		<bouncycastle.version>1.60</bouncycastle.version>
-		<junixsocket.version>2.1.2</junixsocket.version>
+		<junixsocket.version>2.2.0</junixsocket.version>
 		<guava.version>19.0</guava.version>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
Updates junixsocket to version 2.2.0, which adds the following to its supported platforms: Linux ARM 32-bit and 64-bit (e.g., Raspberry Pi), and Windows 10 AMD64.
This change seeks to resolve issues such as https://github.com/docker-java/docker-java/issues/1174

As a quick workaround to the Maven surefire/failsafe plugins throwing "java.lang.noClassDefFoundError: javax/xml/bind/JAXBexception" when trying to perform tests during a simple "mvn clean install," I downgraded those to 2.18.1 as in https://github.com/spring-projects/spring-boot/issues/6254#issuecomment-229601248 and checked that the tests still ran.